### PR TITLE
Prepare backend for shared web host deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 .env
-deploy.sh
+/deploy.sh

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,4 @@
 *.log
 .env
+config.php
+deploy_staging/

--- a/backend/config.example.php
+++ b/backend/config.example.php
@@ -1,0 +1,5 @@
+<?php
+$DB_HOST = 'localhost';
+$DB_NAME = 'hexmap';
+$DB_USER = 'your_db_user';
+$DB_PASS = 'your_db_password';

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and stage hexmap for deployment to a shared web host.
+#
+# Usage: ./deploy.sh [staging_dir]
+#   staging_dir  Directory to write output to (default: ./deploy_staging)
+#
+# The resulting directory layout:
+#   staging_dir/
+#   ├── config.example.php   (copy to config.php and fill in credentials)
+#   ├── src/
+#   │   └── db.php
+#   └── public_html/
+#       ├── .htaccess
+#       ├── api.php
+#       ├── index.html        (frontend)
+#       ├── assets/            (frontend)
+#       └── …
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STAGING="${1:-$SCRIPT_DIR/deploy_staging}"
+
+echo "==> Building frontend…"
+(cd "$PROJECT_ROOT" && npm run build)
+
+echo "==> Preparing staging directory: $STAGING"
+rm -rf "$STAGING"
+mkdir -p "$STAGING/public_html"
+
+# Backend PHP source (not web-accessible)
+cp -r "$SCRIPT_DIR/src" "$STAGING/src"
+
+# Backend public files (webroot)
+cp "$SCRIPT_DIR/public/.htaccess" "$STAGING/public_html/"
+cp "$SCRIPT_DIR/public/api.php" "$STAGING/public_html/"
+
+# Frontend build output (into webroot)
+cp -r "$PROJECT_ROOT/dist/"* "$STAGING/public_html/"
+
+# Config template
+cp "$SCRIPT_DIR/config.example.php" "$STAGING/config.example.php"
+
+echo ""
+echo "==> Staging complete: $STAGING"
+echo ""
+echo "Next steps:"
+echo "  1. Copy config.example.php to config.php and fill in your MySQL credentials."
+echo "  2. Upload the contents of $STAGING to your shared host, e.g.:"
+echo "       rsync -avz $STAGING/ user@host:~/hexmap.example.com/"
+echo "  3. Point your subdomain's document root at the public_html/ directory."

--- a/backend/src/db.php
+++ b/backend/src/db.php
@@ -7,10 +7,19 @@ function getDb(): PDO
     static $pdo = null;
 
     if ($pdo === null) {
-        $host = getenv('DB_HOST') ?: 'localhost';
-        $name = getenv('DB_NAME') ?: 'hexmap';
-        $user = getenv('DB_USER') ?: 'hexmap';
-        $pass = getenv('DB_PASS') ?: 'hexmap';
+        $configFile = __DIR__ . '/../../config.php';
+        if (file_exists($configFile)) {
+            require $configFile;
+            $host = $DB_HOST;
+            $name = $DB_NAME;
+            $user = $DB_USER;
+            $pass = $DB_PASS;
+        } else {
+            $host = getenv('DB_HOST') ?: 'localhost';
+            $name = getenv('DB_NAME') ?: 'hexmap';
+            $user = getenv('DB_USER') ?: 'hexmap';
+            $pass = getenv('DB_PASS') ?: 'hexmap';
+        }
 
         $dsn = "mysql:host=$host;dbname=$name;charset=utf8mb4";
         $pdo = new PDO($dsn, $user, $pass, [

--- a/src/tileDefs.ts
+++ b/src/tileDefs.ts
@@ -14,7 +14,7 @@ import earcut from 'earcut';
 
 import { color, diameter, tileCoordsTo3d } from './hexUtil';
 import { Overlay } from './infoOverlay';
-import { teamRef, TileData } from './mapData';
+import { Resource, teamRef, TileData } from './mapData';
 import { quotation } from './quotations';
 import { displayResource, resources } from './resourceMeshes';
 
@@ -108,7 +108,7 @@ const _teamColor = (teamName: string | undefined) =>
   teamName && teamRef[teamName] && teamRef[teamName].color;
 
 const _createTile =
-  (scene: Scene, resourceFactory: (name: string) => Mesh | undefined) =>
+  (scene: Scene, resourceFactory: (name: Resource) => Mesh | undefined) =>
   (data: TileData): Tile => {
     const { col, row, colorOverride, team, resourceName, coord } = data;
 


### PR DESCRIPTION
## Summary
- Add `config.php` file support to `db.php` for shared hosts where environment variables aren't practical, with fallback to env vars for Docker dev
- Add `backend/deploy.sh` script that builds frontend and stages all files into a directory ready for upload
- Add `backend/config.example.php` credential template
- Fix TypeScript type error in `tileDefs.ts` (resource factory parameter typed as `string` instead of `Resource`)

## Test plan
- [ ] Verify `docker compose up` in `backend/` still works (env var fallback)
- [ ] Run `backend/deploy.sh` and check the staging directory has the correct layout
- [ ] Verify `config.php` is gitignored
- [ ] Run `npm run build` to confirm the TypeScript error is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)