### PR TITLE
Use 127.0.0.1 instead of localhost in config example

### DIFF
--- a/backend/config.example.php
+++ b/backend/config.example.php
@@ -1,5 +1,5 @@
 <?php
-$DB_HOST = 'localhost';
+$DB_HOST = '127.0.0.1';
 $DB_NAME = 'hexmap';
 $DB_USER = 'your_db_user';
 $DB_PASS = 'your_db_password';


### PR DESCRIPTION
## Summary
- Default `$DB_HOST` in `config.example.php` changed from `localhost` to `127.0.0.1`
- Shared hosts may not have the MySQL socket at the default path, causing `SQLSTATE[HY000] [2002] No such file or directory` errors
- Using `127.0.0.1` forces a TCP connection, which works reliably across hosts

## Test plan
- [x] Verified fix resolves the connection error on shared host

🤖 Generated with [Claude Code](https://claude.com/claude-code)