### PR TITLE
Add multi-campaign support

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
       - ./seed.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro
+      - ./seed-campaign2.sql:/docker-entrypoint-initdb.d/03-seed-campaign2.sql:ro
       - mysqldata:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-uhexmap", "-phexmap"]

--- a/backend/public/.htaccess
+++ b/backend/public/.htaccess
@@ -5,5 +5,8 @@ RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
 
+# Route /map/N paths to the map page
+RewriteRule ^map/\d+ map/index.html [L]
+
 # Route /api/* requests to api.php
 RewriteRule ^api(/.*)?$ api.php [L,QSA]

--- a/backend/seed-campaign2.sql
+++ b/backend/seed-campaign2.sql
@@ -1,0 +1,73 @@
+-- Seed data for Campaign 2: Veridian Reach 2026
+-- Two teams, ~18 tiles, 4 attacks
+
+-- ============================================================================
+-- Campaign
+-- ============================================================================
+
+INSERT INTO campaigns (id, name, description, is_active) VALUES
+  (2, 'Veridian Reach 2026', 'The battle for supremacy in the Veridian Reach sector', 1);
+
+-- ============================================================================
+-- Teams
+-- ============================================================================
+
+INSERT INTO teams (id, campaign_id, name, sprite_url, sprite_width, sprite_height, color, display_name) VALUES
+  (4, 2, 'red', 'birb.png', 96, 96, '#FF3333', 'The Crimson Talons'),
+  (5, 2, 'green', 'leaf-solid.png', 512, 512, '#33FF33', 'Verdant Guard');
+
+-- ============================================================================
+-- Team Assets
+-- ============================================================================
+
+INSERT INTO team_assets (team_id, asset_name, score_value) VALUES
+  (4, 'Vital Intel', 3),
+  (4, 'Total War', 2),
+  (4, 'Seized Ground', 1);
+
+INSERT INTO team_assets (team_id, asset_name, score_value) VALUES
+  (5, 'Vital Intel', 2),
+  (5, 'Hearts and Minds', 1),
+  (5, 'Relics', 2);
+
+-- ============================================================================
+-- Tiles
+-- ============================================================================
+
+INSERT INTO tiles (campaign_id, col, `row`, location_name, resource_name, team_id, color_override, defense) VALUES
+  -- Red territory (west)
+  (2, -3, -1, 'Forge Infernus',        'HQ',              4, '#FF3333', 0),
+  (2, -3,  0, 'Pyraxis',               'Manufactorum',     4, NULL,      0),
+  (2, -2, -1, 'Cinderwatch',           'CommandBastion',   4, NULL,      0),
+  (2, -2,  0, 'Ashgrave',              'PowerStation',     4, NULL,      0),
+  (2, -2,  1, 'Emberfell',             'ShieldGenerator',  4, NULL,      0),
+  (2, -1, -1, 'Scorchfield',           NULL,               4, NULL,      0),
+  (2, -1,  0, 'Molten Crossing',       'SpacePort',        4, '#FF3333', 0),
+  -- Neutral / contested (centre)
+  (2,  0, -1, 'Verdis Nexus',          'HiveCity',         NULL, '#333333', 2),
+  (2,  0,  0, 'Thornwall',             'CommandBastion',   NULL, '#333333', 0),
+  (2,  0,  1, 'Misthollow',            'ShieldGenerator',  5, NULL,      0),
+  (2,  1, -1, 'Duskmeadow',            'PowerStation',     4, NULL,      0),
+  -- Green territory (east)
+  (2,  1,  0, 'Briarvale',             NULL,               5, NULL,      0),
+  (2,  1,  1, 'Canopy Reach',          'CommandBastion',   5, NULL,      0),
+  (2,  2, -1, 'Sylvan Beacon',         'SpacePort',        5, NULL,      0),
+  (2,  2,  0, 'Roothold',              'PowerStation',     5, NULL,      0),
+  (2,  2,  1, 'Fernwatch',             'ShieldGenerator',  5, NULL,      0),
+  (2,  3,  0, 'Verdant Citadel',       'HQ',              5, '#33FF33', 0),
+  (2,  3,  1, 'Mosskeep',              'Manufactorum',     5, NULL,      0);
+
+-- ============================================================================
+-- Active Attacks
+-- ============================================================================
+
+INSERT INTO attacks (campaign_id, team_id, from_tile_id, to_tile_id)
+SELECT 2, t.id, ft.id, tt.id
+FROM (SELECT 'red' AS team_name,   -1 AS from_col, 0 AS from_row,  0 AS to_col, 0 AS to_row
+      UNION ALL SELECT 'red',       1, -1,  0, -1
+      UNION ALL SELECT 'green',     0,  1,  0,  0
+      UNION ALL SELECT 'green',     1,  0,  1, -1
+) AS data
+JOIN teams t ON t.name = data.team_name AND t.campaign_id = 2
+JOIN tiles ft ON ft.col = data.from_col AND ft.`row` = data.from_row AND ft.campaign_id = 2
+JOIN tiles tt ON tt.col = data.to_col AND tt.`row` = data.to_row AND tt.campaign_id = 2;

--- a/index.html
+++ b/index.html
@@ -4,13 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="ardboyz_red.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Campaign Map</title>
+    <title>Hexmap Campaigns</title>
   </head>
   <body>
-    <canvas id="app"></canvas>
-    <div hidden id="overlay">Test</div>
-    <div id="scores">
-    </div>
-    <script type="module" src="/src/main.ts"></script>
+    <div id="campaign-list"></div>
+    <script type="module" src="/src/campaigns.ts"></script>
   </body>
 </html>

--- a/map/index.html
+++ b/map/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/ardboyz_red.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Campaign Map</title>
+  </head>
+  <body>
+    <nav id="back-nav"><a href="/">&larr; Campaigns</a></nav>
+    <canvas id="app"></canvas>
+    <div hidden id="overlay">Test</div>
+    <div id="scores"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/src/campaignTypes.ts
+++ b/src/campaignTypes.ts
@@ -1,0 +1,11 @@
+interface Campaign {
+  id: number;
+  name: string;
+  description: string | null;
+  created_at: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+  is_active: boolean;
+}
+
+export type { Campaign };

--- a/src/campaigns.css
+++ b/src/campaigns.css
@@ -1,0 +1,79 @@
+body {
+  background-color: #0a0a0a;
+  color: #ccc;
+  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+h1 {
+  color: #33ff33;
+  margin-bottom: 2rem;
+}
+
+#campaign-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+  max-width: 960px;
+  width: 100%;
+}
+
+.campaign-card {
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+  padding: 1.5rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+}
+
+.campaign-card:hover {
+  border-color: #33ff33;
+  box-shadow: 0 0 12px rgba(51, 255, 51, 0.15);
+}
+
+.campaign-card h2 {
+  color: #33ff33;
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.campaign-card p {
+  margin: 0.25rem 0;
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+.campaign-card .status {
+  display: inline-block;
+  margin-top: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.status.active {
+  background: rgba(51, 255, 51, 0.15);
+  color: #33ff33;
+  border: 1px solid #33ff33;
+}
+
+.status.ended {
+  background: rgba(255, 255, 255, 0.05);
+  color: #888;
+  border: 1px solid #555;
+}
+
+.error-message {
+  color: #ff5555;
+  text-align: center;
+  padding: 2rem;
+}

--- a/src/campaigns.ts
+++ b/src/campaigns.ts
@@ -1,0 +1,49 @@
+import './campaigns.css';
+
+import { Campaign } from './campaignTypes';
+
+const base = import.meta.env.BASE_URL;
+
+const container = document.getElementById('campaign-list')!;
+
+const heading = document.createElement('h1');
+heading.textContent = 'Campaigns';
+document.body.insertBefore(heading, container);
+
+fetch('/api/campaigns')
+  .then((res) => {
+    if (!res.ok) throw new Error(`Failed to load campaigns (${res.status})`);
+    return res.json() as Promise<Campaign[]>;
+  })
+  .then((campaigns) => {
+    if (campaigns.length === 0) {
+      container.innerHTML = '<p class="error-message">No campaigns found.</p>';
+      return;
+    }
+
+    for (const campaign of campaigns) {
+      const card = document.createElement('a');
+      card.className = 'campaign-card';
+      card.href = `${base}map/${campaign.id}`;
+
+      const title = document.createElement('h2');
+      title.textContent = campaign.name;
+      card.appendChild(title);
+
+      if (campaign.description) {
+        const desc = document.createElement('p');
+        desc.textContent = campaign.description;
+        card.appendChild(desc);
+      }
+
+      const status = document.createElement('span');
+      status.className = campaign.ended_at ? 'status ended' : 'status active';
+      status.textContent = campaign.ended_at ? 'Ended' : 'Active';
+      card.appendChild(status);
+
+      container.appendChild(card);
+    }
+  })
+  .catch((err: Error) => {
+    container.innerHTML = `<p class="error-message">${err.message}</p>`;
+  });

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,11 @@ import { Scene } from '@babylonjs/core/scene';
 
 // import { Inspector } from '@babylonjs/inspector';
 import { showAttackArrows } from './attackArrows';
+import { Campaign } from './campaignTypes';
 import { tileCoordsTo3d } from './hexUtil';
 import { overlay, PositionFn } from './infoOverlay';
 import { createKeyScene } from './keyScene';
-import { fetchMapData } from './mapData';
+import { campaignId, fetchMapData } from './mapData';
 import { showScores } from './scores';
 import { showMapIcons } from './teamSprites';
 import { clearHighlight, loadTileFactory } from './tileDefs';
@@ -61,12 +62,12 @@ const createScene = function (engine: Engine) {
   const skyboxMaterial = new StandardMaterial('skyBox', scene);
   skyboxMaterial.backFaceCulling = false;
   const files = [
-    'textures/Space/space_left.jpg',
-    'textures/Space/space_up.jpg',
-    'textures/Space/space_front.jpg',
-    'textures/Space/space_right.jpg',
-    'textures/Space/space_down.jpg',
-    'textures/Space/space_back.jpg',
+    '/textures/Space/space_left.jpg',
+    '/textures/Space/space_up.jpg',
+    '/textures/Space/space_front.jpg',
+    '/textures/Space/space_right.jpg',
+    '/textures/Space/space_down.jpg',
+    '/textures/Space/space_back.jpg',
   ];
   skyboxMaterial.reflectionTexture = CubeTexture.CreateFromImages(files, scene);
   skyboxMaterial.reflectionTexture.coordinatesMode = Texture.SKYBOX_MODE;
@@ -117,13 +118,17 @@ const createScene = function (engine: Engine) {
 };
 
 const canvas = document.getElementById('app') as HTMLCanvasElement;
-DefaultLoadingScreen.DefaultLogoUrl = 'ardboyz.png';
+DefaultLoadingScreen.DefaultLogoUrl = '/ardboyz.png';
 const engine = new Engine(canvas, true, { stencil: true });
 engine.displayLoadingUI();
 
 const { scene, camera } = createScene(engine);
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-// Inspector.Show(scene, {});
+
+void fetch(`/api/campaigns/${campaignId}`)
+  .then((res) => (res.ok ? (res.json() as Promise<Campaign>) : null))
+  .then((c) => {
+    if (c) document.title = c.name;
+  });
 const keyScenes: Scene[] = [];
 keyScenes.push(createKeyScene(engine, camera, 'HQ', { scale: 0.7 }));
 keyScenes.push(createKeyScene(engine, camera, 'CommandBastion', { row: 1 }));

--- a/src/mapData.ts
+++ b/src/mapData.ts
@@ -43,9 +43,32 @@ interface MapData {
 
 const teamRef: Record<string, Team> = {};
 
+const getCampaignId = (): number => {
+  const base = import.meta.env.BASE_URL; // e.g. "/" or "/hexmap/"
+  const path = window.location.pathname;
+  // Strip the base prefix to get the app-relative path
+  const relative = path.startsWith(base) ? path.slice(base.length) : path;
+  // Expect "map/N" or "map/N/..."
+  const match = relative.match(/^map\/(\d+)/);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  // No valid campaign ID — redirect to listing
+  window.location.href = base;
+  // Return 0 as fallback (redirect will navigate away)
+  return 0;
+};
+
+const campaignId = getCampaignId();
+
 const fetchMapData = (): Promise<MapData> => {
-  return fetch('/api/campaigns/1/map-data')
-    .then((response) => response.json() as Promise<MapData>)
+  return fetch(`/api/campaigns/${campaignId}/map-data`)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load map data (${response.status})`);
+      }
+      return response.json() as Promise<MapData>;
+    })
     .then((mapData) => {
       for (const team of mapData.teams) {
         teamRef[team.name] = team;
@@ -54,4 +77,4 @@ const fetchMapData = (): Promise<MapData> => {
     });
 };
 
-export { fetchMapData, MapData, Resource, Team, teamRef, TileData };
+export { campaignId, fetchMapData, MapData, Resource, Team, teamRef, TileData };

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,23 @@
+#back-nav {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 100;
+}
+
+#back-nav a {
+  color: #33ff33;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+#back-nav a:hover {
+  background: rgba(0, 0, 0, 0.85);
+}
+
 #app {
   /* width: 100%; */
 

--- a/src/teamSprites.ts
+++ b/src/teamSprites.ts
@@ -16,7 +16,7 @@ const showMapIcons = (scene: Scene, mapData: MapData): void => {
       team.name,
       new SpriteManager(
         `${team.name}Manager`,
-        team.spriteUrl,
+        `/${team.spriteUrl}`,
         100,
         { width: team.spriteWidth, height: team.spriteHeight },
         scene,
@@ -29,7 +29,7 @@ const showMapIcons = (scene: Scene, mapData: MapData): void => {
       team.name,
       new SpriteManager(
         `${team.name}SM`,
-        `shield_${team.name}.png`,
+        `/shield_${team.name}.png`,
         100,
         { width: 72, height: 72 },
         scene,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,34 @@
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import content from '@originjs/vite-plugin-content';
+import path from 'node:path';
+
+/**
+ * Vite plugin to rewrite /map/N paths to /map/index.html during dev,
+ * so the dev server serves the map page for path-based campaign URLs.
+ */
+function mapPathRewrite(): Plugin {
+  return {
+    name: 'map-path-rewrite',
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        if (req.url && /^\/map\/\d+/.test(req.url)) {
+          req.url = '/map/index.html';
+        }
+        next();
+      });
+    },
+  };
+}
 
 export default defineConfig({
   base: '/',
   build: {
     rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        map: path.resolve(__dirname, 'map/index.html'),
+      },
       output: {
         manualChunks: {
           babylon: ['@babylonjs/core'],
@@ -15,5 +38,13 @@ export default defineConfig({
       },
     },
   },
-  plugins: [tsconfigPaths(), content()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
+  plugins: [mapPathRewrite(), tsconfigPaths(), content()],
 });


### PR DESCRIPTION
## Summary

- Converts from a single-page app to a Vite multi-page app with two entry points: a campaign listing page at `/` and the map viewer at `/map/N`
- Campaign listing fetches from `GET /api/campaigns` and renders clickable cards linking to each campaign's map
- Map page extracts campaign ID from the URL path, with redirect to listing if no valid ID is found
- Adds second campaign seed data ("Veridian Reach 2026" — 2 teams, 18 tiles, 4 attacks)
- Fixes image paths to be absolute so assets load correctly from `/map/` routes

## Test plan

- [ ] Start backend: `cd backend && docker compose down -v && docker compose up`
- [ ] Start frontend: `npm run dev`
- [ ] Visit `http://localhost:5173/` — should show both campaigns listed
- [ ] Click a campaign — should navigate to `/map/1` or `/map/2` and render the map with all images loading
- [ ] Visit `/map/` without an ID — should redirect to the listing
- [ ] Verify `npm run build` succeeds
- [ ] Verify `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)