### PR TITLE
feat: player role abilities

### DIFF
--- a/backend/public/api.php
+++ b/backend/public/api.php
@@ -138,6 +138,18 @@ if ($method === 'GET' && $path === '/api/auth/login') {
     require_once __DIR__ . '/../src/handlers/campaign-management.php';
     handleRemoveCampaignGm((int)$m[1], (int)$m[2]);
 
+} elseif ($method === 'GET' && preg_match('#^/api/campaigns/(\d+)/players$#', $path, $m)) {
+    require_once __DIR__ . '/../src/handlers/campaign-management.php';
+    handleListCampaignPlayers((int)$m[1]);
+
+} elseif ($method === 'POST' && preg_match('#^/api/campaigns/(\d+)/players$#', $path, $m)) {
+    require_once __DIR__ . '/../src/handlers/campaign-management.php';
+    handleAddCampaignPlayer((int)$m[1]);
+
+} elseif ($method === 'DELETE' && preg_match('#^/api/campaigns/(\d+)/players/(\d+)$#', $path, $m)) {
+    require_once __DIR__ . '/../src/handlers/campaign-management.php';
+    handleRemoveCampaignPlayer((int)$m[1], (int)$m[2]);
+
 // ── Sprite routes (GM protected) ─────────────────────────────────────────────
 } elseif ($method === 'GET' && preg_match('#^/api/campaigns/(\d+)/teams/(\d+)/sprites$#', $path, $m)) {
     require_once __DIR__ . '/../src/handlers/sprite.php';

--- a/backend/src/handlers/admin.php
+++ b/backend/src/handlers/admin.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../helpers.php';
 require_once __DIR__ . '/../db.php';
 require_once __DIR__ . '/../middleware.php';
+require_once __DIR__ . '/../hex.php';
 
 // ── Tiles ────────────────────────────────────────────────────────────────────
 
@@ -124,44 +125,113 @@ function handleUpdateTile(int $campaignId, int $tileId): never
 
 /**
  * POST /api/campaigns/:campaignId/attacks
- * Body: { "team_id": 3, "from_tile_id": 10, "to_tile_id": 11 }
+ * Body (GM): { "team_id": 3, "from_tile_id": 10, "to_tile_id": 11 }
+ * Body (player): { "from_tile_id": 10, "to_tile_id": 11 }
  * Creates a new unresolved attack.
- * Requires GM role for the campaign.
+ * GMs: no adjacency enforcement. Players: from_tile must be owned by their team,
+ * to_tile must be adjacent (or long-range via Spaceport), and must not be their own tile.
  */
 function handleCreateAttack(int $campaignId): never
 {
-    $user = requireAuth();
-    requireGm($user, $campaignId);
+    $user  = requireAuth();
+    $db    = getDb();
+    $roles = getUserRoles($db, $user['id']);
+
+    $isGm         = isGmForCampaign($roles, $campaignId);
+    $playerTeamId = getPlayerTeam($roles, $campaignId);
+
+    if (!$isGm && $playerTeamId === null) {
+        jsonResponse(['error' => 'Forbidden'], 403);
+    }
 
     $body = json_decode(file_get_contents('php://input'), true) ?? [];
 
-    // Cast and validate — all three must be positive integers
-    $teamId     = isset($body['team_id'])      && is_int($body['team_id'])      ? $body['team_id']      : 0;
     $fromTileId = isset($body['from_tile_id']) && is_int($body['from_tile_id']) ? $body['from_tile_id'] : 0;
     $toTileId   = isset($body['to_tile_id'])   && is_int($body['to_tile_id'])   ? $body['to_tile_id']   : 0;
 
-    if ($teamId <= 0 || $fromTileId <= 0 || $toTileId <= 0) {
-        jsonResponse(['error' => 'team_id, from_tile_id, and to_tile_id are required positive integers'], 400);
+    if ($fromTileId <= 0 || $toTileId <= 0) {
+        jsonResponse(['error' => 'from_tile_id and to_tile_id are required positive integers'], 400);
     }
 
     if ($fromTileId === $toTileId) {
         jsonResponse(['error' => 'from_tile_id and to_tile_id must differ'], 400);
     }
 
-    $db = getDb();
+    if ($isGm) {
+        // GM path: team_id required in body
+        $teamId = isset($body['team_id']) && is_int($body['team_id']) ? $body['team_id'] : 0;
+        if ($teamId <= 0) {
+            jsonResponse(['error' => 'team_id is required for GM attacks'], 400);
+        }
 
-    // Verify team belongs to campaign
-    $stmt = $db->prepare('SELECT id FROM teams WHERE id = ? AND campaign_id = ?');
-    $stmt->execute([$teamId, $campaignId]);
-    if (!$stmt->fetch()) {
-        jsonResponse(['error' => 'Team not found in this campaign'], 404);
-    }
+        // Verify team belongs to campaign
+        $stmt = $db->prepare('SELECT id FROM teams WHERE id = ? AND campaign_id = ?');
+        $stmt->execute([$teamId, $campaignId]);
+        if (!$stmt->fetch()) {
+            jsonResponse(['error' => 'Team not found in this campaign'], 404);
+        }
 
-    // Verify both tiles belong to campaign
-    $stmt = $db->prepare('SELECT id FROM tiles WHERE id IN (?, ?) AND campaign_id = ?');
-    $stmt->execute([$fromTileId, $toTileId, $campaignId]);
-    if ($stmt->rowCount() !== 2) {
-        jsonResponse(['error' => 'One or both tiles not found in this campaign'], 404);
+        // Verify both tiles belong to campaign
+        $stmt = $db->prepare('SELECT id FROM tiles WHERE id IN (?, ?) AND campaign_id = ?');
+        $stmt->execute([$fromTileId, $toTileId, $campaignId]);
+        if ($stmt->rowCount() !== 2) {
+            jsonResponse(['error' => 'One or both tiles not found in this campaign'], 404);
+        }
+    } else {
+        // Player path: team_id from role, validate ownership and adjacency
+        $teamId = $playerTeamId;
+
+        // Fetch from_tile: must belong to campaign and be owned by player's team
+        $stmt = $db->prepare(
+            'SELECT id, col, row, resource_name, team_id FROM tiles WHERE id = ? AND campaign_id = ?'
+        );
+        $stmt->execute([$fromTileId, $campaignId]);
+        $fromTile = $stmt->fetch();
+        if (!$fromTile) {
+            jsonResponse(['error' => 'From tile not found in this campaign'], 404);
+        }
+        if ((int)$fromTile['team_id'] !== $teamId) {
+            jsonResponse(['error' => 'From tile is not owned by your team'], 422);
+        }
+
+        // Fetch to_tile: must belong to campaign and not be owned by player's team
+        $stmt = $db->prepare(
+            'SELECT id, col, row, team_id FROM tiles WHERE id = ? AND campaign_id = ?'
+        );
+        $stmt->execute([$toTileId, $campaignId]);
+        $toTile = $stmt->fetch();
+        if (!$toTile) {
+            jsonResponse(['error' => 'To tile not found in this campaign'], 404);
+        }
+        if ($toTile['team_id'] !== null && (int)$toTile['team_id'] === $teamId) {
+            jsonResponse(['error' => 'Cannot attack a tile owned by your own team'], 422);
+        }
+
+        // Validate adjacency (or Spaceport long-range rule)
+        $fromCol = (int)$fromTile['col'];
+        $fromRow = (int)$fromTile['row'];
+        $toCol   = (int)$toTile['col'];
+        $toRow   = (int)$toTile['row'];
+
+        if (!areHexesAdjacent($fromCol, $fromRow, $toCol, $toRow)) {
+            // Long-range attack: from_tile must have Spaceport resource
+            if ($fromTile['resource_name'] !== 'Spaceport') {
+                jsonResponse(['error' => 'Target tile is not adjacent to the source tile'], 422);
+            }
+            // Only one long-range (non-adjacent) attack allowed from a Spaceport tile at a time
+            $stmt = $db->prepare(
+                'SELECT a.id, t.col, t.row
+                   FROM attacks a
+                   JOIN tiles t ON t.id = a.to_tile_id
+                  WHERE a.campaign_id = ? AND a.from_tile_id = ? AND a.resolved_at IS NULL'
+            );
+            $stmt->execute([$campaignId, $fromTileId]);
+            foreach ($stmt->fetchAll() as $existing) {
+                if (!areHexesAdjacent($fromCol, $fromRow, (int)$existing['col'], (int)$existing['row'])) {
+                    jsonResponse(['error' => 'Spaceport is already in use for another long-range attack'], 422);
+                }
+            }
+        }
     }
 
     $stmt = $db->prepare(
@@ -175,15 +245,21 @@ function handleCreateAttack(int $campaignId): never
 
 /**
  * DELETE /api/campaigns/:campaignId/attacks/:attackId
- * Resolves an attack: sets resolved_at and records in attack_history.
- * Requires GM role for the campaign.
+ * GMs: resolves the attack (sets resolved_at, records outcome='resolved' in history).
+ * Players: cancels their own team's attack (sets resolved_at, records outcome='cancelled').
  */
 function handleResolveAttack(int $campaignId, int $attackId): never
 {
-    $user = requireAuth();
-    requireGm($user, $campaignId);
+    $user  = requireAuth();
+    $db    = getDb();
+    $roles = getUserRoles($db, $user['id']);
 
-    $db = getDb();
+    $isGm         = isGmForCampaign($roles, $campaignId);
+    $playerTeamId = getPlayerTeam($roles, $campaignId);
+
+    if (!$isGm && $playerTeamId === null) {
+        jsonResponse(['error' => 'Forbidden'], 403);
+    }
 
     // Verify attack belongs to this campaign and is unresolved
     $stmt = $db->prepare(
@@ -198,6 +274,13 @@ function handleResolveAttack(int $campaignId, int $attackId): never
         jsonResponse(['error' => 'Attack not found or already resolved'], 404);
     }
 
+    // Players may only cancel attacks belonging to their own team
+    if (!$isGm && (int)$attack['team_id'] !== $playerTeamId) {
+        jsonResponse(['error' => 'You can only cancel your own team\'s attacks'], 403);
+    }
+
+    $outcome = $isGm ? 'resolved' : 'cancelled';
+
     $db->prepare('UPDATE attacks SET resolved_at = NOW() WHERE id = ?')
        ->execute([$attackId]);
 
@@ -210,7 +293,7 @@ function handleResolveAttack(int $campaignId, int $attackId): never
         $attack['from_tile_id'],
         $attack['to_tile_id'],
         $attack['created_at'],
-        'resolved',
+        $outcome,
     ]);
 
     jsonResponse(['ok' => true]);

--- a/backend/src/handlers/campaign-management.php
+++ b/backend/src/handlers/campaign-management.php
@@ -517,3 +517,105 @@ function handleRemoveCampaignGm(int $campaignId, int $targetUserId): never
 
     jsonResponse(['ok' => true]);
 }
+
+// ── Player management ─────────────────────────────────────────────────────────
+
+/**
+ * GET /api/campaigns/:campaignId/players
+ * Returns list of players for the campaign, grouped with their team_id.
+ * Requires GM or superuser.
+ * Returns: [{ user_id, display_name, email, team_id }]
+ */
+function handleListCampaignPlayers(int $campaignId): never
+{
+    $user = requireAuth();
+    requireGm($user, $campaignId);
+
+    $db   = getDb();
+    $stmt = $db->prepare(
+        'SELECT u.id AS user_id, u.display_name, u.email, r.team_id
+           FROM user_roles r
+           JOIN users u ON r.user_id = u.id
+          WHERE r.role_type = ? AND r.campaign_id = ?
+          ORDER BY r.team_id, u.display_name'
+    );
+    $stmt->execute(['player', $campaignId]);
+    $rows = $stmt->fetchAll();
+
+    $result = array_map(function (array $r): array {
+        return [
+            'user_id'      => (int)$r['user_id'],
+            'display_name' => $r['display_name'],
+            'email'        => $r['email'],
+            'team_id'      => (int)$r['team_id'],
+        ];
+    }, $rows);
+
+    jsonResponse($result);
+}
+
+/**
+ * POST /api/campaigns/:campaignId/players
+ * Body: { "user_id": N, "team_id": N }
+ * Assigns a player role for the user in this campaign for a specific team.
+ * Requires GM or superuser. Idempotent.
+ */
+function handleAddCampaignPlayer(int $campaignId): never
+{
+    $user = requireAuth();
+    requireGm($user, $campaignId);
+
+    $db   = getDb();
+    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+
+    $targetUserId = isset($body['user_id']) && is_int($body['user_id']) ? $body['user_id'] : 0;
+    $teamId       = isset($body['team_id']) && is_int($body['team_id']) ? $body['team_id'] : 0;
+
+    if ($targetUserId <= 0 || $teamId <= 0) {
+        jsonResponse(['error' => 'user_id and team_id are required positive integers'], 400);
+    }
+
+    // Verify user exists
+    $stmt = $db->prepare('SELECT id FROM users WHERE id = ?');
+    $stmt->execute([$targetUserId]);
+    if (!$stmt->fetch()) {
+        jsonResponse(['error' => 'User not found'], 404);
+    }
+
+    // Verify team belongs to campaign
+    $stmt = $db->prepare('SELECT id FROM teams WHERE id = ? AND campaign_id = ?');
+    $stmt->execute([$teamId, $campaignId]);
+    if (!$stmt->fetch()) {
+        jsonResponse(['error' => 'Team not found in this campaign'], 404);
+    }
+
+    // INSERT IGNORE makes this idempotent (UNIQUE constraint: user_id, role_type, campaign_id, team_id)
+    $db->prepare(
+        'INSERT IGNORE INTO user_roles (user_id, role_type, campaign_id, team_id) VALUES (?, ?, ?, ?)'
+    )->execute([$targetUserId, 'player', $campaignId, $teamId]);
+
+    jsonResponse(['ok' => true], 201);
+}
+
+/**
+ * DELETE /api/campaigns/:campaignId/players/:userId
+ * Removes the player role for the user in this campaign.
+ * Requires GM or superuser.
+ */
+function handleRemoveCampaignPlayer(int $campaignId, int $targetUserId): never
+{
+    $user = requireAuth();
+    requireGm($user, $campaignId);
+
+    $db   = getDb();
+    $stmt = $db->prepare(
+        'DELETE FROM user_roles WHERE user_id = ? AND role_type = ? AND campaign_id = ?'
+    );
+    $stmt->execute([$targetUserId, 'player', $campaignId]);
+
+    if ($stmt->rowCount() === 0) {
+        jsonResponse(['error' => 'Player role not found for this user in this campaign'], 404);
+    }
+
+    jsonResponse(['ok' => true]);
+}

--- a/backend/src/hex.php
+++ b/backend/src/hex.php
@@ -1,0 +1,27 @@
+<?php
+// backend/src/hex.php
+// Hex grid utilities for odd-q offset coordinates.
+
+declare(strict_types=1);
+
+/**
+ * Returns true if the two tiles at (col1,row1) and (col2,row2) are adjacent
+ * in an odd-q offset hex grid (odd columns shifted up / lower Z in 3D).
+ *
+ * Neighbour offsets derived from tileCoordsTo3d in src/hexUtil.ts:
+ *   even col: adjacent at dc=±1 with dr=0 or dr=+1, plus same col dr=±1
+ *   odd  col: adjacent at dc=±1 with dr=0 or dr=-1, plus same col dr=±1
+ */
+function areHexesAdjacent(int $col1, int $row1, int $col2, int $row2): bool
+{
+    $neighbours = ($col1 % 2 === 0)
+        ? [[1, 0], [1, 1], [-1, 0], [-1, 1], [0, -1], [0, 1]]   // even col
+        : [[1, 0], [1, -1], [-1, 0], [-1, -1], [0, -1], [0, 1]]; // odd col
+
+    foreach ($neighbours as [$dc, $dr]) {
+        if ($col1 + $dc === $col2 && $row1 + $dr === $row2) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/backend/src/middleware.php
+++ b/backend/src/middleware.php
@@ -93,6 +93,11 @@ function isGmForCampaign(array $roles, int $campaignId): bool
     return false;
 }
 
+function isPlayerForCampaign(array $roles, int $campaignId): bool
+{
+    return getPlayerTeam($roles, $campaignId) !== null;
+}
+
 /**
  * Returns the team_id the player is assigned to in this campaign, or null.
  */

--- a/src/admin/campaign.ts
+++ b/src/admin/campaign.ts
@@ -9,6 +9,7 @@ import {
   AdminCampaign,
   AdminGm,
   AdminMapData,
+  AdminPlayer,
   AdminSpriteHistory,
   AdminTile,
   AdminUser,
@@ -30,18 +31,31 @@ interface CampaignDetailData {
   mapData: AdminMapData;
   teams: CampaignTeam[];
   gms: AdminGm[];
+  players: AdminPlayer[];
   currentUser: AdminUser;
 }
 
 async function loadData(campaignId: number): Promise<CampaignDetailData> {
-  const [campaign, mapData, teams, gms, currentUser] = await Promise.all([
+  // Load current user first to determine which endpoints to call.
+  const currentUser = await api.get<AdminUser>('/auth/me');
+  const isGmOrSuperuser = currentUser.roles.some(
+    (r) =>
+      r.role_type === 'superuser' ||
+      (r.role_type === 'gm' && r.campaign_id === campaignId),
+  );
+
+  const [campaign, mapData, teams, gms, players] = await Promise.all([
     api.get<AdminCampaign>(`/campaigns/${campaignId}`),
     api.get<AdminMapData>(`/campaigns/${campaignId}/map-data`),
     api.get<CampaignTeam[]>(`/campaigns/${campaignId}/teams`),
-    api.get<AdminGm[]>(`/campaigns/${campaignId}/gms`),
-    api.get<AdminUser>('/auth/me'),
+    isGmOrSuperuser
+      ? api.get<AdminGm[]>(`/campaigns/${campaignId}/gms`)
+      : Promise.resolve<AdminGm[]>([]),
+    isGmOrSuperuser
+      ? api.get<AdminPlayer[]>(`/campaigns/${campaignId}/players`)
+      : Promise.resolve<AdminPlayer[]>([]),
   ]);
-  return { campaign, mapData, teams, gms, currentUser };
+  return { campaign, mapData, teams, gms, players, currentUser };
 }
 
 type CampaignState = 'not_started' | 'active' | 'paused' | 'ended';
@@ -1250,6 +1264,461 @@ function renderAssetEditor(
   });
 }
 
+// Odd-q offset hex adjacency — mirrors areHexesAdjacent in backend/src/hex.php.
+function areHexesAdjacent(
+  col1: number,
+  row1: number,
+  col2: number,
+  row2: number,
+): boolean {
+  const neighbours =
+    col1 % 2 === 0
+      ? [
+          [1, 0],
+          [1, 1],
+          [-1, 0],
+          [-1, 1],
+          [0, -1],
+          [0, 1],
+        ]
+      : [
+          [1, 0],
+          [1, -1],
+          [-1, 0],
+          [-1, -1],
+          [0, -1],
+          [0, 1],
+        ];
+  return neighbours.some(([dc, dr]) => col1 + dc === col2 && row1 + dr === row2);
+}
+
+function renderPlayerManager(
+  container: HTMLElement,
+  players: AdminPlayer[],
+  teams: CampaignTeam[],
+  campaignId: number,
+  reload: () => void,
+): void {
+  const teamById = Object.fromEntries(teams.map((t) => [t.id, t]));
+
+  // Group players by team
+  const byTeam = new Map<number, AdminPlayer[]>();
+  for (const p of players) {
+    if (!byTeam.has(p.team_id)) byTeam.set(p.team_id, []);
+    byTeam.get(p.team_id)!.push(p);
+  }
+
+  const teamSections = teams
+    .map((team) => {
+      const teamPlayers = byTeam.get(team.id) ?? [];
+      const rows = teamPlayers
+        .map(
+          (p) => `
+        <li style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid #333">
+          <span>${esc(p.display_name)} <span style="color:#888;font-size:0.85em">${esc(
+            p.email,
+          )}</span></span>
+          <button data-remove-player-id="${p.user_id}"
+            style="padding:2px 8px;cursor:pointer;background:#7f1d1d;color:white;border:none;border-radius:3px;font-size:0.85em">
+            Remove
+          </button>
+        </li>`,
+        )
+        .join('');
+
+      return `
+        <div style="margin-bottom:16px">
+          <strong style="color:${esc(team.color)}">${esc(team.display_name)}</strong>
+          ${
+            teamPlayers.length === 0
+              ? '<p style="color:#888;font-size:0.9em;margin:4px 0 0">No players assigned.</p>'
+              : `<ul style="list-style:none;padding:0;margin:4px 0 0">${rows}</ul>`
+          }
+        </div>`;
+    })
+    .join('');
+
+  const teamOptions = teams
+    .map((t) => `<option value="${t.id}">${esc(t.display_name)}</option>`)
+    .join('');
+
+  container.innerHTML = `
+    <h3 style="margin:0 0 12px">Players</h3>
+    ${
+      teams.length === 0
+        ? '<p style="color:#888;font-size:0.9em">No teams in this campaign yet.</p>'
+        : teamSections
+    }
+    <details style="margin-top:8px">
+      <summary style="cursor:pointer;color:#7ab3f0;margin-bottom:8px">+ Add player</summary>
+      <div style="display:flex;flex-direction:column;gap:8px;max-width:480px;margin-top:8px">
+        <label>Team
+          <select id="player-team-select"
+            style="display:block;width:100%;margin-top:2px;background:#2a2a2a;color:#eee;border:1px solid #555;padding:4px;border-radius:3px">
+            ${teamOptions}
+          </select>
+        </label>
+        <div style="display:flex;gap:8px;align-items:flex-start">
+          <input id="player-search-input" type="text" placeholder="Search by email or name (min 2 chars)"
+            style="flex:1;padding:6px 8px;background:#2a2a2a;color:#eee;border:1px solid #555;border-radius:3px">
+          <button id="player-search-btn"
+            style="padding:6px 12px;background:#444;color:white;border:none;border-radius:3px;cursor:pointer;white-space:nowrap">
+            Search
+          </button>
+        </div>
+        <ul id="player-search-results" style="list-style:none;padding:0;margin:0"></ul>
+        <span id="player-search-error" style="color:#f87171;font-size:0.85em"></span>
+      </div>
+    </details>
+  `;
+
+  // Remove player buttons
+  container
+    .querySelectorAll<HTMLButtonElement>('button[data-remove-player-id]')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const userId = Number(btn.dataset['removePlayerId']);
+        btn.disabled = true;
+        void api
+          .delete(`/campaigns/${campaignId}/players/${userId}`)
+          .then(() => reload())
+          .catch((err: unknown) => {
+            alert(
+              `Failed to remove player: ${
+                err instanceof ApiError ? err.message : String(err)
+              }`,
+            );
+            btn.disabled = false;
+          });
+      });
+    });
+
+  const searchInput = document.getElementById('player-search-input') as HTMLInputElement;
+  const searchResults = document.getElementById('player-search-results')!;
+  const searchError = document.getElementById('player-search-error')!;
+  const teamSelect = document.getElementById('player-team-select') as HTMLSelectElement;
+
+  interface UserResult {
+    id: number;
+    display_name: string;
+    email: string;
+  }
+
+  const doSearch = (): void => {
+    const q = searchInput.value.trim();
+    searchError.textContent = '';
+    searchResults.innerHTML = '';
+
+    if (q.length < 2) {
+      searchError.textContent = 'Enter at least 2 characters to search.';
+      return;
+    }
+
+    void api
+      .get<UserResult[]>(`/users/search?q=${encodeURIComponent(q)}`)
+      .then((users) => {
+        if (users.length === 0) {
+          searchResults.innerHTML =
+            '<li style="padding:6px 0;color:#888">No users found.</li>';
+          return;
+        }
+        searchResults.innerHTML = users
+          .map(
+            (u) => `
+          <li style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid #333">
+            <span>${esc(u.display_name)} <span style="color:#888;font-size:0.85em">${esc(
+              u.email,
+            )}</span></span>
+            <button data-add-player-id="${u.id}"
+              style="padding:2px 8px;cursor:pointer;background:#166534;color:white;border:none;border-radius:3px;font-size:0.85em">
+              Add Player
+            </button>
+          </li>`,
+          )
+          .join('');
+
+        searchResults
+          .querySelectorAll<HTMLButtonElement>('button[data-add-player-id]')
+          .forEach((btn) => {
+            btn.addEventListener('click', () => {
+              const userId = Number(btn.dataset['addPlayerId']);
+              const selectedTeamId = Number(teamSelect.value);
+              btn.disabled = true;
+              void api
+                .post(`/campaigns/${campaignId}/players`, {
+                  user_id: userId,
+                  team_id: selectedTeamId,
+                })
+                .then(() => reload())
+                .catch((err: unknown) => {
+                  searchError.textContent = esc(
+                    err instanceof ApiError ? err.message : String(err),
+                  );
+                  btn.disabled = false;
+                });
+            });
+          });
+      })
+      .catch((err: unknown) => {
+        searchError.textContent = esc(
+          err instanceof ApiError ? err.message : String(err),
+        );
+      });
+  };
+
+  document.getElementById('player-search-btn')?.addEventListener('click', doSearch);
+  searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') doSearch();
+  });
+
+  // Suppress unused variable warning — teamById used for future extensibility
+  void teamById;
+}
+
+function renderPlayerView(
+  container: HTMLElement,
+  campaignId: number,
+  playerTeamId: number,
+  mapData: AdminMapData,
+  teams: CampaignTeam[],
+  reload: () => void,
+): void {
+  const playerTeam = teams.find((t) => t.id === playerTeamId);
+  const teamName = playerTeam?.name ?? '';
+  const teamDisplayName = playerTeam?.display_name ?? 'Your Team';
+  const teamColor = playerTeam?.color ?? '#888';
+
+  // Tiles owned by the player's team
+  const myTiles = mapData.map.filter((t) => t.team === teamName);
+
+  // Active attacks for the player's team
+  const myAttacks = mapData.attacks.filter((a: AdminAttack) => a.team === teamName);
+
+  // Assets for the player's team
+  const teamAssets = mapData.teams.find((t) => t.name === teamName)?.assets ?? {};
+
+  const tileRows = myTiles
+    .map(
+      (t) => `
+    <tr>
+      <td style="padding:6px 8px;font-family:monospace">${esc(t.coord)}</td>
+      <td style="padding:6px 8px">${esc(t.locationName ?? '—')}</td>
+      <td style="padding:6px 8px">${esc(t.resourceName ?? '—')}</td>
+      <td style="padding:6px 8px">${t.defence ?? 0}</td>
+    </tr>`,
+    )
+    .join('');
+
+  const attackRows = myAttacks
+    .map(
+      (a: AdminAttack) => `
+    <tr>
+      <td style="padding:6px 8px;font-family:monospace">${esc(
+        `${a.from.col},${a.from.row}`,
+      )}</td>
+      <td style="padding:6px 8px;font-family:monospace">${esc(
+        `${a.to.col},${a.to.row}`,
+      )}</td>
+      <td style="padding:6px 8px">
+        <button data-cancel-attack-id="${a.id}"
+          style="padding:2px 8px;cursor:pointer;background:#7f1d1d;color:white;border:none;border-radius:3px">
+          Cancel
+        </button>
+      </td>
+    </tr>`,
+    )
+    .join('');
+
+  const fromTileOptions = myTiles
+    .map(
+      (t) =>
+        `<option value="${t.id}" data-col="${t.col}" data-row="${
+          t.row
+        }" data-resource="${esc(t.resourceName ?? '')}">${esc(t.coord)}${
+          t.locationName ? ' — ' + esc(t.locationName) : ''
+        }</option>`,
+    )
+    .join('');
+
+  const assetEntries = Object.entries(teamAssets);
+  const assetRows =
+    assetEntries.length === 0
+      ? '<p style="color:#888;font-size:0.9em">No assets.</p>'
+      : assetEntries
+          .map(
+            ([name, val]) =>
+              `<div style="display:flex;justify-content:space-between;padding:4px 0;border-bottom:1px solid #333;max-width:360px"><span>${esc(
+                name,
+              )}</span><strong>${val}</strong></div>`,
+          )
+          .join('');
+
+  container.innerHTML = `
+    <header style="padding:16px 24px;border-bottom:1px solid #333;display:flex;justify-content:space-between;align-items:center">
+      <span><a href="/admin" style="color:#7ab3f0">← Campaigns</a></span>
+      <strong style="color:${esc(teamColor)}">${esc(teamDisplayName)}</strong>
+      <span style="font-size:0.85em;color:#888">Player view</span>
+    </header>
+    <main style="padding:24px;max-width:900px;display:grid;gap:32px">
+
+      <section>
+        <h3 style="margin:0 0 12px">Your Tiles</h3>
+        ${
+          myTiles.length === 0
+            ? '<p style="color:#888">Your team owns no tiles.</p>'
+            : `<table style="width:100%;border-collapse:collapse;font-size:0.9em">
+              <thead><tr style="border-bottom:1px solid #444;text-align:left">
+                <th style="padding:6px 8px">Coord</th>
+                <th style="padding:6px 8px">Location</th>
+                <th style="padding:6px 8px">Resource</th>
+                <th style="padding:6px 8px">Defence</th>
+              </tr></thead>
+              <tbody>${tileRows}</tbody>
+            </table>`
+        }
+      </section>
+
+      <section>
+        <h3 style="margin:0 0 12px">Active Attacks</h3>
+        ${
+          myAttacks.length === 0
+            ? '<p style="color:#888">No active attacks.</p>'
+            : `<table style="width:100%;border-collapse:collapse;font-size:0.9em;margin-bottom:16px">
+              <thead><tr style="border-bottom:1px solid #444;text-align:left">
+                <th style="padding:6px 8px">From</th>
+                <th style="padding:6px 8px">To</th>
+                <th style="padding:6px 8px"></th>
+              </tr></thead>
+              <tbody>${attackRows}</tbody>
+            </table>`
+        }
+
+        <details style="margin-top:8px">
+          <summary style="cursor:pointer;color:#7ab3f0;margin-bottom:8px">+ Submit attack</summary>
+          <div style="display:flex;flex-direction:column;gap:8px;max-width:360px;margin-top:8px">
+            ${
+              myTiles.length === 0
+                ? '<p style="color:#888;font-size:0.9em">Your team owns no tiles to attack from.</p>'
+                : `<label>From tile
+                <select id="player-atk-from"
+                  style="display:block;width:100%;margin-top:2px;background:#2a2a2a;color:#eee;border:1px solid #555;padding:4px;border-radius:3px">
+                  ${fromTileOptions}
+                </select>
+              </label>
+              <label>To tile
+                <select id="player-atk-to"
+                  style="display:block;width:100%;margin-top:2px;background:#2a2a2a;color:#eee;border:1px solid #555;padding:4px;border-radius:3px">
+                  <option value="">— select a From tile first —</option>
+                </select>
+              </label>
+              <button id="player-atk-submit"
+                style="padding:6px 16px;background:#1d4ed8;color:white;border:none;border-radius:3px;cursor:pointer;align-self:flex-start">
+                Submit Attack
+              </button>`
+            }
+          </div>
+        </details>
+      </section>
+
+      <section>
+        <h3 style="margin:0 0 12px">Assets</h3>
+        ${assetRows}
+      </section>
+
+    </main>
+  `;
+
+  // Cancel attack buttons
+  container
+    .querySelectorAll<HTMLButtonElement>('button[data-cancel-attack-id]')
+    .forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const attackId = Number(btn.dataset['cancelAttackId']);
+        btn.disabled = true;
+        void api
+          .delete(`/campaigns/${campaignId}/attacks/${attackId}`)
+          .then(() => reload())
+          .catch((err: unknown) => {
+            alert(
+              `Failed to cancel attack: ${
+                err instanceof ApiError ? err.message : String(err)
+              }`,
+            );
+            btn.disabled = false;
+          });
+      });
+    });
+
+  if (myTiles.length === 0) return;
+
+  const fromSelect = document.getElementById('player-atk-from') as HTMLSelectElement;
+  const toSelect = document.getElementById('player-atk-to') as HTMLSelectElement;
+
+  const updateToOptions = (): void => {
+    const selectedOption = fromSelect.selectedOptions[0];
+    if (!selectedOption) return;
+
+    const fromCol = Number(selectedOption.dataset['col']);
+    const fromRow = Number(selectedOption.dataset['row']);
+    const fromResource = selectedOption.dataset['resource'] ?? '';
+    const fromTileId = Number(selectedOption.value);
+
+    // Check if Spaceport is already in use (non-adjacent active attack from this tile)
+    const spaceportInUse = myAttacks.some((a: AdminAttack) => {
+      if (a.from.col !== fromCol || a.from.row !== fromRow) return false;
+      return !areHexesAdjacent(fromCol, fromRow, a.to.col, a.to.row);
+    });
+
+    const hasSpaceport = fromResource === 'Spaceport' && !spaceportInUse;
+
+    // Build To options: adjacent tiles OR all tiles (Spaceport), excluding own team's tiles
+    const validTargets = mapData.map.filter((t) => {
+      if (t.id === fromTileId) return false;
+      if (t.team === teamName) return false; // cannot attack own tiles
+      if (hasSpaceport) return true; // Spaceport: any non-own tile
+      return areHexesAdjacent(fromCol, fromRow, t.col, t.row);
+    });
+
+    if (validTargets.length === 0) {
+      toSelect.innerHTML = '<option value="">— no valid targets —</option>';
+    } else {
+      toSelect.innerHTML = validTargets
+        .map(
+          (t) =>
+            `<option value="${t.id}">${esc(t.coord)}${
+              t.locationName ? ' — ' + esc(t.locationName) : ''
+            }${t.team ? ' (' + esc(t.team) + ')' : ''}</option>`,
+        )
+        .join('');
+    }
+  };
+
+  fromSelect.addEventListener('change', updateToOptions);
+  updateToOptions(); // populate on initial render
+
+  document.getElementById('player-atk-submit')?.addEventListener('click', () => {
+    const fromId = Number(fromSelect.value);
+    const toId = Number(toSelect.value);
+    if (!fromId || !toId) {
+      alert('Please select both a From tile and a To tile.');
+      return;
+    }
+    void api
+      .post(`/campaigns/${campaignId}/attacks`, {
+        from_tile_id: fromId,
+        to_tile_id: toId,
+      })
+      .then(() => reload())
+      .catch((err: unknown) => {
+        alert(
+          `Failed to submit attack: ${
+            err instanceof ApiError ? err.message : String(err)
+          }`,
+        );
+      });
+  });
+}
+
 export async function renderCampaignDetail(
   container: HTMLElement,
   campaignId: number,
@@ -1260,7 +1729,32 @@ export async function renderCampaignDetail(
   // Called after attack create/resolve to keep state consistent.
   async function render(): Promise<void> {
     try {
-      const { campaign, mapData, teams, gms, currentUser } = await loadData(campaignId);
+      const { campaign, mapData, teams, gms, players, currentUser } = await loadData(
+        campaignId,
+      );
+
+      const isSuperuser = currentUser.roles.some((r) => r.role_type === 'superuser');
+      const isGm = currentUser.roles.some(
+        (r) =>
+          r.role_type === 'superuser' ||
+          (r.role_type === 'gm' && r.campaign_id === campaignId),
+      );
+      const playerRole = currentUser.roles.find(
+        (r) => r.role_type === 'player' && r.campaign_id === campaignId,
+      );
+
+      // Players who are not also GMs/superusers see a restricted player view.
+      if (!isGm && playerRole) {
+        renderPlayerView(
+          container,
+          campaignId,
+          playerRole.team_id,
+          mapData,
+          teams,
+          () => void render(),
+        );
+        return;
+      }
 
       container.innerHTML = `
         <header style="padding:16px 24px;border-bottom:1px solid #333;display:flex;justify-content:space-between;align-items:center">
@@ -1276,6 +1770,7 @@ export async function renderCampaignDetail(
           <section id="section-assets"></section>
           <section id="section-teams"></section>
           <section id="section-gms"></section>
+          <section id="section-players"></section>
         </main>
       `;
 
@@ -1299,7 +1794,6 @@ export async function renderCampaignDetail(
         teams,
         campaignId,
       );
-      const isSuperuser = currentUser.roles.some((r) => r.role_type === 'superuser');
 
       renderLifecycle(
         document.getElementById('section-lifecycle')!,
@@ -1327,6 +1821,14 @@ export async function renderCampaignDetail(
           () => void render(),
         );
       }
+      // GMs (and superusers) can manage players
+      renderPlayerManager(
+        document.getElementById('section-players')!,
+        players,
+        teams,
+        campaignId,
+        () => void render(),
+      );
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) return;
       container.innerHTML = `<p style="padding:24px;color:#f87171">Error: ${esc(

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -66,6 +66,14 @@ export interface AdminGm {
   email: string;
 }
 
+// AdminPlayer is only used for the players-list endpoint response.
+export interface AdminPlayer {
+  user_id: number;
+  display_name: string;
+  email: string;
+  team_id: number;
+}
+
 export interface AdminSpriteHistory {
   id: number;
   sprite_url: string;


### PR DESCRIPTION
## Summary

- GMs can assign users as players for a specific team via a new **Players** tab on the campaign page (user search + team dropdown, same UX pattern as GM assignment)
- Players log into `/admin` and see a restricted **player view** showing their team's tiles, active attacks, asset scores, and a submit-attack form
- Players can submit attacks from their owned tiles, with adjacency enforced server-side (Spaceport resource allows long-range attacks, limited to one at a time)
- Players can cancel their own team's attacks; GMs retain exclusive resolve authority

## Backend changes

- `backend/src/hex.php` — new `areHexesAdjacent()` helper (odd-q offset)
- `backend/src/middleware.php` — added `isPlayerForCampaign()`
- `backend/src/handlers/admin.php` — `handleCreateAttack` and `handleResolveAttack` extended for player-scoped permissions and validation
- `backend/src/handlers/campaign-management.php` — new `handleListCampaignPlayers`, `handleAddCampaignPlayer`, `handleRemoveCampaignPlayer`
- `backend/public/api.php` — 3 new player routes (`GET/POST/DELETE /api/campaigns/:id/players`)

## Frontend changes

- `src/admin/types.ts` — added `AdminPlayer` interface
- `src/admin/campaign.ts` — role-conditional data loading, `renderPlayerManager` (GM view), `renderPlayerView` (player view), `areHexesAdjacent` client-side helper for To-tile filtering

## Test plan

- [ ] Assign a user as a player via the Players tab; verify they appear grouped by team
- [ ] Log in as a player; verify GM controls are not visible
- [ ] Submit an attack from an owned tile to an adjacent non-owned tile; verify it appears on the map
- [ ] Attempt to attack a non-adjacent tile without Spaceport; expect rejection
- [ ] Submit a long-range attack from a Spaceport tile; verify it succeeds then blocks a second long-range from the same tile
- [ ] Cancel an attack as a player; verify it disappears
- [ ] Resolve an attack as a GM; verify `outcome=resolved` in history
- [ ] Run `npm test` — all 12 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)