### PR TITLE
feat: allow players to set defence on their own tiles

### DIFF
--- a/backend/src/handlers/admin.php
+++ b/backend/src/handlers/admin.php
@@ -18,11 +18,18 @@ require_once __DIR__ . '/../hex.php';
  */
 function handleUpdateTile(int $campaignId, int $tileId): never
 {
-    $user = requireAuth();
-    requireGm($user, $campaignId);
+    $user  = requireAuth();
+    $db    = getDb();
+    $roles = getUserRoles($db, $user['id']);
+
+    $isGm         = isGmForCampaign($roles, $campaignId);
+    $playerTeamId = getPlayerTeam($roles, $campaignId);
+
+    if (!$isGm && $playerTeamId === null) {
+        jsonResponse(['error' => 'Forbidden'], 403);
+    }
 
     $body = json_decode(file_get_contents('php://input'), true) ?? [];
-    $db   = getDb();
 
     // Verify tile belongs to this campaign
     $stmt = $db->prepare('SELECT id, team_id FROM tiles WHERE id = ? AND campaign_id = ?');
@@ -30,6 +37,18 @@ function handleUpdateTile(int $campaignId, int $tileId): never
     $tile = $stmt->fetch();
     if (!$tile) {
         jsonResponse(['error' => 'Tile not found'], 404);
+    }
+
+    if (!$isGm) {
+        // Players may only update defense on their own tiles
+        if ((int)$tile['team_id'] !== $playerTeamId) {
+            jsonResponse(['error' => 'You do not own this tile'], 403);
+        }
+        foreach (array_keys($body) as $key) {
+            if ($key !== 'defense') {
+                jsonResponse(['error' => 'Players may only update defense'], 403);
+            }
+        }
     }
 
     $setClauses = [];

--- a/src/admin/campaign.ts
+++ b/src/admin/campaign.ts
@@ -1540,6 +1540,15 @@ function renderPlayerView(
     )
     .join('');
 
+  const tileOptions = myTiles
+    .map(
+      (t) =>
+        `<option value="${t.id}">${esc(t.coord)}${
+          t.locationName ? ' — ' + esc(t.locationName) : ''
+        }</option>`,
+    )
+    .join('');
+
   const assetEntries = Object.entries(teamAssets);
   const assetRows =
     assetEntries.length === 0
@@ -1614,6 +1623,33 @@ function renderPlayerView(
               <button id="player-atk-submit"
                 style="padding:6px 16px;background:#1d4ed8;color:white;border:none;border-radius:3px;cursor:pointer;align-self:flex-start">
                 Submit Attack
+              </button>`
+            }
+          </div>
+        </details>
+      </section>
+
+      <section>
+        <h3 style="margin:0 0 12px">Place Defence</h3>
+        <details style="margin-top:8px">
+          <summary style="cursor:pointer;color:#7ab3f0;margin-bottom:8px">+ Set defence on a tile</summary>
+          <div style="display:flex;flex-direction:column;gap:8px;max-width:360px;margin-top:8px">
+            ${
+              myTiles.length === 0
+                ? '<p style="color:#888;font-size:0.9em">Your team owns no tiles.</p>'
+                : `<label>Tile
+                <select id="player-def-tile"
+                  style="display:block;width:100%;margin-top:2px;background:#2a2a2a;color:#eee;border:1px solid #555;padding:4px;border-radius:3px">
+                  ${tileOptions}
+                </select>
+              </label>
+              <label>Defence value
+                <input id="player-def-value" type="number" min="0" value="0"
+                  style="display:block;width:100%;margin-top:2px;background:#2a2a2a;color:#eee;border:1px solid #555;padding:4px;border-radius:3px">
+              </label>
+              <button id="player-def-submit"
+                style="padding:6px 16px;background:#1d4ed8;color:white;border:none;border-radius:3px;cursor:pointer;align-self:flex-start">
+                Set Defence
               </button>`
             }
           </div>
@@ -1715,6 +1751,32 @@ function renderPlayerView(
             err instanceof ApiError ? err.message : String(err)
           }`,
         );
+      });
+  });
+
+  const defSubmitBtn = document.getElementById(
+    'player-def-submit',
+  ) as HTMLButtonElement | null;
+  defSubmitBtn?.addEventListener('click', () => {
+    const tileId = Number(
+      (document.getElementById('player-def-tile') as HTMLSelectElement).value,
+    );
+    const value = Number(
+      (document.getElementById('player-def-value') as HTMLInputElement).value,
+    );
+    if (!Number.isInteger(value) || value < 0) {
+      alert('Defence must be a non-negative whole number.');
+      return;
+    }
+    defSubmitBtn.disabled = true;
+    void api
+      .patch(`/campaigns/${campaignId}/tiles/${tileId}`, { defense: value })
+      .then(() => reload())
+      .catch((err: unknown) => {
+        alert(
+          `Failed to set defence: ${err instanceof ApiError ? err.message : String(err)}`,
+        );
+        defSubmitBtn.disabled = false;
       });
   });
 }

--- a/src/tileDefs.ts
+++ b/src/tileDefs.ts
@@ -70,6 +70,7 @@ const _content = (data: TileData) => {
       `<div>Controlled by <span class="${data.team}">${displayName}</span></div>`,
     );
   }
+  if (data.defence) lines.push(`<div>Defence: ${data.defence}</div>`);
   if (data.terrainRules)
     lines.push(
       `<div>Terrain: <a target="_blank" href="${data.terrainRules.url}">${data.terrainRules.name}</a></div>`,


### PR DESCRIPTION
## Summary
- Extends `PATCH /api/campaigns/:id/tiles/:tileId` to accept player-role requests, restricted to the `defense` field on tiles owned by their team (GMs retain full access)
- Adds a "Place Defence" section to the player view in the admin panel with a tile select, value input, and submit button
- Shows defence count in the tile info popover on the main map

## Test Plan
- [ ] Log in as a player; verify "Place Defence" section appears in the player view
- [ ] Set a defence value on an owned tile; confirm shield sprites appear on the map
- [ ] Attempt to set defence on a tile owned by another team; expect 403
- [ ] Attempt to update a non-defence field as a player; expect 403
- [ ] Log in as a GM; confirm existing tile editing still works unchanged
- [ ] Click a tile with defence on the map; confirm "Defence: N" appears in the popover
- [ ] All automated tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)